### PR TITLE
Adding ChainTip bounties to the list of platforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A comprehensive curated list of Bug Bounty Programs and write-ups from the Bug B
 - [FreedomSponsors](https://freedomsponsors.org/)
 - [FOSS Factory](http://www.fossfactory.org/)
 - [Synack](https://www.synack.com/)
+- [ChainTip](http://www.chaintip.org/github#tip-issue)
 
 ### Available Programs
 - [123Contact Form](http://www.123contactform.com/security-acknowledgements.htm)


### PR DESCRIPTION
@chaintip fixes #20

Linked to the issue tipping section on the GitHub usage page of the ChainTip site. This position on the page clearly shows how to create and claim bounties.

@djadmin, please modify this inclusion as you desire. This @block-spider account is a helper account for ChainTip.