### PR TITLE
Remove "Natures Organics"

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,6 @@ A comprehensive curated list of Bug Bounty Programs and write-ups from the Bug B
 - [Motorola Solutions](mailto:security@motorolasolutions.com)
 - [Mozilla](https://www.mozilla.org/en-US/security/bug-bounty/)
 - [mynxt.info](https://cobalt.io/mynxt-info)
-- [Natures Organics](mailto:ict@naturesorganics.com.au)
 - [NCSC](mailto:cert@ncsc.nl)
 - [Nearby Live](https://hackerone.com/nearby)
 - [Nest](mailto:security@nest.com)


### PR DESCRIPTION
Natures Organics does not have, and has never had, a bug bounty program. Not sure what data this list was compiled from.