### PR TITLE
Add Akira - AI pentest co-pilot for bug bounty hunters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A comprehensive curated list of Bug Bounty Programs and write-ups from the Bug B
 - [Contribution guide](contributing.md)
 
 ### Getting Started
+- [Akira](https://github.com/Kalp1774/akira) - Open-source AI pentest co-pilot that runs inside Claude Code, Gemini CLI, and Cursor. Chains recon, secret hunting, exploitation, and reporting across a session - each phase hands its findings to the next. Requires HTTP evidence for every finding before flagging it.
 - [How to Become a Successful Bug Bounty Hunter](https://hackerone.com/blog/what-great-hackers-share)
 - [Researcher Resources - How to become a Bug Bounty Hunter](https://forum.bugcrowd.com/t/researcher-resources-how-to-become-a-bug-bounty-hunter/1102)
 - [Bug Bounties 101](https://whitton.io/articles/bug-bounties-101-getting-started/)


### PR DESCRIPTION
[Akira](https://github.com/Kalp1774/akira) is an open-source AI pentest co-pilot that runs natively inside Claude Code, Gemini CLI, and Cursor.

**What makes it different:**
- Maintains a `session.json` across phases - recon findings feed directly into exploit targeting, which feeds into the report. No re-explaining context between prompts.
- Requires raw HTTP request/response as proof before flagging any finding. The model cannot claim a vulnerability exists without demonstrating it.
- 12 skills covering the full bug bounty workflow: subdomain enum, live host detection, JS secret hunting, XSS/SQLi/SSRF/SSTI/XXE, JWT attacks, race conditions, OAuth, cloud audit, AD chains
- No server required - runs inside your existing AI coding environment

MIT licensed, free.